### PR TITLE
Fix a race condition when browser was killed before it finishes initialization + updated webdriverio

### DIFF
--- a/examples/karma.conf.js
+++ b/examples/karma.conf.js
@@ -3,10 +3,10 @@ var path = require('path');
 module.exports = function(config) {
 
     var webDriverConfig = {
-      desiredCapabilities: {
+      capabilities: {
         version: '27.0'
       },
-      host: 'localhost',
+      hostname: 'localhost',
       port: 4444,
       path: '/wd/hub'
     };

--- a/index.js
+++ b/index.js
@@ -18,8 +18,7 @@ var buildOptions = function(args){
 var SeleniumBrowser = function (baseBrowserDecorator, args, logger) {
   var options = buildOptions(args),
       log = logger.create('webdriverio'),
-      self = this, 
-      browserRunning = false;
+      self = this;
 
   baseBrowserDecorator(this);
 
@@ -30,14 +29,11 @@ var SeleniumBrowser = function (baseBrowserDecorator, args, logger) {
     self.browser = webdriverio
       .remote(options)
       .init()
-      .url(url)
-      .then(function(){
-        browserRunning = true;
-      });
+      .url(url);
   };
 
   this.on('kill', function(done){
-    if(!browserRunning){
+    if(!self.browser){
       process.nextTick(done);
     }
 

--- a/index.js
+++ b/index.js
@@ -8,31 +8,45 @@ var SeleniumBrowser = function (baseBrowserDecorator, args, logger) {
   baseBrowserDecorator(this);
 
   this.name = 'selenium for ' + args.browserName;
+  this.navigated = false;
 
   this._start = function(url) {
     log.info('Selenium browser started at http://' + args.config.hostname + ':' + args.config.port + args.config.path);
     remote(args.config).then(browser => {
       self.browser = browser;
-      browser.url(url);
+      return browser.url(url);
+    }).then(() => {
+      self.navigated = true;
+      log.info(self.name + ' navigated to the Karma URL');
     }).catch(e => {
+      self.navigated = true;
       log.info('Error retrieving a selenium instance: ', e.message);
     });
   };
 
-  this.on('kill', async function(done){
+  this.on('kill', function(done) {
     if(!self.browser){
       process.nextTick(done);
       return;
     }
 
-    try {
-      await self.browser.deleteSession();
-      log.info('Browser closed');
-    } catch (error) {
-      log.error('Browser closed with error:\n' + error.message + '\n' + error.stack);
-    }
-    self._done();
-    done();
+    // need to delay the end request in case the navigation request has not completed yet
+    const delayedEnd = () => {
+      if (self.navigated) {
+        self.browser.deleteSession().then(() => {
+          log.info('Browser closed');
+          self._done();
+          done();
+        }).catch((error) => {
+          log.error('Browser closed with error:\n' + error.message + '\n' + error.stack);
+          self._done();
+          done();
+        });
+      } else {
+        setTimeout(delayedEnd, 100);
+      }
+    };
+    delayedEnd();
   });
 };
 

--- a/index.js
+++ b/index.js
@@ -43,6 +43,11 @@ var SeleniumBrowser = function (baseBrowserDecorator, args, logger) {
         log.info('Browser closed');
         self._done();
         done();
+      })
+      .catch(error => {
+        log.error('Browser closed with error:\n' + error.message + '\n' + error.stack);
+        self._done();
+        done();
       });
   });
 };

--- a/index.js
+++ b/index.js
@@ -38,7 +38,9 @@ var SeleniumBrowser = function (baseBrowserDecorator, args, logger) {
     }
 
     self.browser
-      .end()
+      .then(function() {
+        return self.browser.end();
+      })
       .then(function(){
         log.info('Browser closed');
         self._done();

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "node ./node_modules/selenium-standalone/bin/selenium-standalone install && node ./node_modules/selenium-standalone/bin/selenium-standalone start"
   },
   "dependencies": {
-    "webdriverio": "^4.2.3"
+    "webdriverio": "^5.18.0"
   },
   "author": "Mindy Kim",
   "license": "MIT",


### PR DESCRIPTION
In our tests remote browser (IE) would not close because `kill` was called before `browserRunning = true` was executed.